### PR TITLE
Fix TorchScript exporting

### DIFF
--- a/model/layers.py
+++ b/model/layers.py
@@ -5,7 +5,7 @@ import torch.nn.functional as F
 from torch.nn.parameter import Parameter
 
 
-def gem(x, p=3, eps=1e-6):
+def gem(x, p=torch.ones(1)*3, eps: float = 1e-6):
     return F.avg_pool2d(x.clamp(min=eps).pow(p), (x.size(-2), x.size(-1))).pow(1./p)
 
 
@@ -33,5 +33,5 @@ class L2Norm(nn.Module):
         super().__init__()
         self.dim = dim
     def forward(self, x):
-        return F.normalize(x, p=2, dim=self.dim)
+        return F.normalize(x, p=2.0, dim=self.dim)
 


### PR DESCRIPTION
When I tried to export `GeoLocalizationNet` to TorchScript with `torch.jit.script` I stumbled upon some typing issues:

1.
```
Expected a default value of type Tensor (inferred) on parameter "p". Because "p"
was not annotated with an explicit type it is assumed to be type 'Tensor'.
File "CosPlace\model\layers.py", line 8
def gem(x, p=3, eps=1e-6):
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    return F.avg_pool2d(x.clamp(min=eps).pow(p), (x.size(-2), x.size(-1))).pow(1./p)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
```
2.
```
Expected a default value of type Tensor (inferred) on parameter "eps". Because
"eps" was not annotated with an explicit type it is assumed to be type 'Tensor'.
File "CosPlace\model\layers.py", line 8
def gem(x, p=torch.ones(1)*3, eps=1e-6):
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    return F.avg_pool2d(x.clamp(min=eps).pow(p), (x.size(-2), x.size(-1))).pow(1./p)
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
```
3.
```
Expected a value of type 'float' for argument 'p' but instead found type 'int'.
File "CosPlace\model\layers.py", line 36
  def forward(self, x):
      return F.normalize(x, p=2, dim=self.dim)
             ~~~~~~~~~~~ <--- HERE
```

I've made the minimal changes to fix this.