### PR TITLE
Added control over image resizing and backbone freezing

### DIFF
--- a/datasets/test_dataset.py
+++ b/datasets/test_dataset.py
@@ -10,8 +10,9 @@ import datasets.dataset_utils as dataset_utils
 
 
 class TestDataset(data.Dataset):
-    def __init__(self, args, dataset_folder, database_folder="database",
-                 queries_folder="queries", positive_dist_threshold=25):
+    def __init__(self, dataset_folder, database_folder="database",
+                 queries_folder="queries", positive_dist_threshold=25,
+                 image_size=512, resize_test_imgs=False):
         self.database_folder = dataset_folder + "/" + database_folder
         self.queries_folder = dataset_folder + "/" + queries_folder
         self.database_paths = dataset_utils.read_images_paths(self.database_folder, get_abs_path=True)
@@ -37,8 +38,9 @@ class TestDataset(data.Dataset):
         self.queries_num = len(self.queries_paths)
 
         transforms_list = []
-        if args.resize_test_imgs:
-            transforms_list += [transforms.Resize(args.image_size, antialias=True)]
+        if resize_test_imgs:
+            # Resize to image_size along the shorter side while maintaining aspect ratio
+            transforms_list += [transforms.Resize(image_size, antialias=True)]
         transforms_list += [
                 transforms.ToTensor(),
                 transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),

--- a/datasets/test_dataset.py
+++ b/datasets/test_dataset.py
@@ -10,7 +10,7 @@ import datasets.dataset_utils as dataset_utils
 
 
 class TestDataset(data.Dataset):
-    def __init__(self, dataset_folder, database_folder="database",
+    def __init__(self, args, dataset_folder, database_folder="database",
                  queries_folder="queries", positive_dist_threshold=25):
         self.database_folder = dataset_folder + "/" + database_folder
         self.queries_folder = dataset_folder + "/" + queries_folder
@@ -35,11 +35,15 @@ class TestDataset(data.Dataset):
         
         self.database_num = len(self.database_paths)
         self.queries_num = len(self.queries_paths)
-        
-        self.base_transform = transforms.Compose([
-            transforms.ToTensor(),
-            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
-        ])
+
+        transforms_list = []
+        if args.resize_test_imgs:
+            transforms_list += [transforms.Resize(args.image_size, antialias=True)]
+        transforms_list += [
+                transforms.ToTensor(),
+                transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+            ]
+        self.base_transform = transforms.Compose(transforms_list)
     
     @staticmethod
     def open_image(path):

--- a/datasets/train_dataset.py
+++ b/datasets/train_dataset.py
@@ -63,7 +63,7 @@ class TrainDataset(torch.utils.data.Dataset):
                                   contrast=args.contrast,
                                   saturation=args.saturation,
                                   hue=args.hue),
-                    T.RandomResizedCrop([512, 512], scale=[1-args.random_resized_crop, 1], antialias=True),
+                    T.RandomResizedCrop([args.image_size, args.image_size], scale=[1-args.random_resized_crop, 1], antialias=True),
                     T.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
                 ])
     

--- a/parser.py
+++ b/parser.py
@@ -16,6 +16,8 @@ def parse_arguments(is_training: bool = True):
                         choices=["VGG16", "ResNet18", "ResNet50", "ResNet101", "ResNet152"], help="_")
     parser.add_argument("--fc_output_dim", type=int, default=512,
                         help="Output dimension of final fully connected layer")
+    parser.add_argument("--train_all_layers", default=False, action="store_true",
+                        help="If true, train all layers of the backbone")
     # Training parameters
     parser.add_argument("--use_amp16", action="store_true",
                         help="use Automatic Mixed Precision")
@@ -27,6 +29,11 @@ def parse_arguments(is_training: bool = True):
     parser.add_argument("--iterations_per_epoch", type=int, default=10000, help="_")
     parser.add_argument("--lr", type=float, default=0.00001, help="_")
     parser.add_argument("--classifiers_lr", type=float, default=0.01, help="_")
+    parser.add_argument("--image_size", type=int, default=512,
+                        help="Width and height of training images (1:1 aspect ratio))")
+    parser.add_argument("--resize_test_imgs", default=False, action="store_true",
+                        help="If the test images should be resized to image_size along"
+                          "the shorter side while maintaining aspect ratio")
     # Data augmentation
     parser.add_argument("--brightness", type=float, default=0.7, help="_")
     parser.add_argument("--contrast", type=float, default=0.7, help="_")

--- a/train.py
+++ b/train.py
@@ -56,9 +56,11 @@ logging.info(f"Using {len(groups)} groups")
 logging.info(f"The {len(groups)} groups have respectively the following number of classes {[len(g) for g in groups]}")
 logging.info(f"The {len(groups)} groups have respectively the following number of images {[g.get_images_num() for g in groups]}")
 
-val_ds = TestDataset(args, args.val_set_folder, positive_dist_threshold=args.positive_dist_threshold)
-test_ds = TestDataset(args, args.test_set_folder, queries_folder="queries_v1",
-                      positive_dist_threshold=args.positive_dist_threshold)
+val_ds = TestDataset(args.val_set_folder, positive_dist_threshold=args.positive_dist_threshold,
+                     image_size=args.image_size, resize_test_imgs=args.resize_test_imgs)
+test_ds = TestDataset(args.test_set_folder, queries_folder="queries_v1",
+                      positive_dist_threshold=args.positive_dist_threshold,
+                      image_size=args.image_size, resize_test_imgs=args.resize_test_imgs)
 logging.info(f"Validation set: {val_ds}")
 logging.info(f"Test set: {test_ds}")
 

--- a/train.py
+++ b/train.py
@@ -30,7 +30,7 @@ logging.info(f"Arguments: {args}")
 logging.info(f"The outputs are being saved in {args.output_folder}")
 
 #### Model
-model = cosplace_network.GeoLocalizationNet(args.backbone, args.fc_output_dim)
+model = cosplace_network.GeoLocalizationNet(args.backbone, args.fc_output_dim, args.train_all_layers)
 
 logging.info(f"There are {torch.cuda.device_count()} GPUs and {multiprocessing.cpu_count()} CPUs.")
 
@@ -56,8 +56,8 @@ logging.info(f"Using {len(groups)} groups")
 logging.info(f"The {len(groups)} groups have respectively the following number of classes {[len(g) for g in groups]}")
 logging.info(f"The {len(groups)} groups have respectively the following number of images {[g.get_images_num() for g in groups]}")
 
-val_ds = TestDataset(args.val_set_folder, positive_dist_threshold=args.positive_dist_threshold)
-test_ds = TestDataset(args.test_set_folder, queries_folder="queries_v1",
+val_ds = TestDataset(args, args.val_set_folder, positive_dist_threshold=args.positive_dist_threshold)
+test_ds = TestDataset(args, args.test_set_folder, queries_folder="queries_v1",
                       positive_dist_threshold=args.positive_dist_threshold)
 logging.info(f"Validation set: {val_ds}")
 logging.info(f"Test set: {test_ds}")
@@ -86,7 +86,7 @@ if args.augmentation_device == "cuda":
                                                     contrast=args.contrast,
                                                     saturation=args.saturation,
                                                     hue=args.hue),
-            augmentations.DeviceAgnosticRandomResizedCrop([512, 512],
+            augmentations.DeviceAgnosticRandomResizedCrop([args.image_size, args.image_size],
                                                           scale=[1-args.random_resized_crop, 1]),
             T.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
         ])


### PR DESCRIPTION
These changes enable training the network with image sizes other than 512x512 (arg: --image_size).

Optionally, the test images can also be resized (arg: --resize_test_imgs).

When training with image sizes that drastically differ from the image sizes used for pretraining the backbones, all backbone layers should be set to trainable using the --train_all_layers arg.