### PR TITLE
Added support for Efficientnet backbones

### DIFF
--- a/cosplace_model/cosplace_network.py
+++ b/cosplace_model/cosplace_network.py
@@ -15,8 +15,12 @@ CHANNELS_NUM_IN_LAST_CONV = {
     "ResNet152": 2048,
     "VGG16": 512,
     "EfficientNet_B0": 1280,
+    "EfficientNet_B1": 1280,
     "EfficientNet_B2": 1408,
+    "EfficientNet_B3": 1536,
     "EfficientNet_B4": 1792,
+    "EfficientNet_B5": 2048,
+    "EfficientNet_B6": 2304,
     "EfficientNet_B7": 2560,
 }
 
@@ -97,7 +101,6 @@ def get_backbone(backbone_name : str, train_all_layers : bool) -> Tuple[torch.nn
         layers = list(backbone.children())[:-2] # Remove avg pooling and FC layer
     
     backbone = torch.nn.Sequential(*layers)
-    
     features_dim = CHANNELS_NUM_IN_LAST_CONV[backbone_name]
     
     return backbone, features_dim

--- a/parser.py
+++ b/parser.py
@@ -15,8 +15,9 @@ def parse_arguments(is_training: bool = True):
     parser.add_argument("--backbone", type=str, default="ResNet18",
                         choices=["VGG16",
                                  "ResNet18", "ResNet50", "ResNet101", "ResNet152",
-                                 "EfficientNet_B0", "EfficientNet_B2",
-                                 "EfficientNet_B4", "EfficientNet_B7"], help="_")
+                                 "EfficientNet_B0", "EfficientNet_B1", "EfficientNet_B2",
+                                 "EfficientNet_B3", "EfficientNet_B4", "EfficientNet_B5", 
+                                 "EfficientNet_B6", "EfficientNet_B7"], help="_")
     parser.add_argument("--fc_output_dim", type=int, default=512,
                         help="Output dimension of final fully connected layer")
     parser.add_argument("--train_all_layers", default=False, action="store_true",

--- a/parser.py
+++ b/parser.py
@@ -13,7 +13,10 @@ def parse_arguments(is_training: bool = True):
     parser.add_argument("--min_images_per_class", type=int, default=10, help="_")
     # Model parameters
     parser.add_argument("--backbone", type=str, default="ResNet18",
-                        choices=["VGG16", "ResNet18", "ResNet50", "ResNet101", "ResNet152"], help="_")
+                        choices=["VGG16",
+                                 "ResNet18", "ResNet50", "ResNet101", "ResNet152",
+                                 "EfficientNet_B0", "EfficientNet_B2",
+                                 "EfficientNet_B4", "EfficientNet_B7"], help="_")
     parser.add_argument("--fc_output_dim", type=int, default=512,
                         help="Output dimension of final fully connected layer")
     parser.add_argument("--train_all_layers", default=False, action="store_true",


### PR DESCRIPTION
Added support for some of the backbones from the EfficientNet family.

Test results:
```
train.py --backbone EfficientNet_B0
< test - #q: 1000; #db: 2805840 >: R@1: 63.6, R@5: 73.5, R@10: 77.0, R@20: 80.8
```